### PR TITLE
Add documentation for Non KDE and Gnome users

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,15 +47,6 @@ Here's how to Configure Baruch Main WiFi and eduroam to work on Linux*
 
 
 
-## Non-KDE/GNOME Users:
-Some of you may not be using desktop environments that comes with the tools. Thus in this section we will go with the package [networkmanagerapplet](https://gitlab.gnome.org/GNOME/network-manager-applet/) from Gnome.
-
-On Arch Linux this package is named `network-manager-applet` which can be found in the [AUR](https://archlinux.org/packages/?name=network-manager-applet).
-On NixOS this package is name [`networkmanagerapplet`](https://github.com/NixOS/nixpkgs/blob/fe51d34885f7b5e3e7b59572796e1bcb427eccb1/pkgs/by-name/ne/networkmanagerapplet/package.nix#L88).
-This package should be widely availiable across most of the distros, search for your own package repository if you are not using the above distributions.
-
-After you have the package installed, launch it and follow the KDE section of [Main WiFi](#on-kde-1) and [Eduroam](#eduroam)(#on-kde-1) to proceed.
-
 ### Troubleshooting eduroam:
 eduroam seems to be the finickiest out of the 2, so if you run into issues, here are some steps you can take.
 
@@ -70,6 +61,15 @@ eduroam seems to be the finickiest out of the 2, so if you run into issues, here
     - I am not sure how often they replace these keys, it shouldn't be often as they affect quite a lot of things. A couple sources I've seen is usually around 20-30 years, but I do not know how Baruch handles this.
 
     <img src="https://github.com/debainz/baruch-wifi-on-Linux/blob/main/img/eduroam-ca-contents.png" width=50% height=50%>
+
+## Non-KDE/GNOME Users:
+Some of you may not be using desktop environments that comes with the tools. Thus in this section we will go with the package [networkmanagerapplet](https://gitlab.gnome.org/GNOME/network-manager-applet/) from Gnome.
+
+On Arch Linux this package is named `network-manager-applet` which can be found in the [AUR](https://archlinux.org/packages/?name=network-manager-applet).
+On NixOS this package is name [`networkmanagerapplet`](https://github.com/NixOS/nixpkgs/blob/fe51d34885f7b5e3e7b59572796e1bcb427eccb1/pkgs/by-name/ne/networkmanagerapplet/package.nix#L88).
+This package should be widely availiable across most of the distros, search for your own package repository if you are not using the above distributions.
+
+After you have the package installed, launch it and follow the KDE section of [Main WiFi](#on-kde-1) and [Eduroam](#eduroam)(#on-kde-1) to proceed.
 
 Hopefully this documentation proved helpful, this was one of the major pain points that prevented me from daily-driving NixOS (or your preferred distribution) from sophomore year. Now that this is solved, I can finally make more progress of fully daily-driving NixOS, and I hope you do the same.
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,15 @@ Here's how to Configure Baruch Main WiFi and eduroam to work on Linux*
 
 
 
+## Non-KDE/GNOME Users:
+Some of you may not be using desktop environments that comes with the tools. Thus in this section we will go with the package [networkmanagerapplet](https://gitlab.gnome.org/GNOME/network-manager-applet/) from Gnome.
+
+On Arch Linux this package is named `network-manager-applet` which can be found in the [AUR](https://archlinux.org/packages/?name=network-manager-applet).
+On NixOS this package is name [`networkmanagerapplet`](https://github.com/NixOS/nixpkgs/blob/fe51d34885f7b5e3e7b59572796e1bcb427eccb1/pkgs/by-name/ne/networkmanagerapplet/package.nix#L88).
+This package should be widely availiable across most of the distros, search for your own package repository if you are not using the above distributions.
+
+After you have the package installed, launch it and follow the KDE section of [Main WiFi](#on-kde-1) and [Eduroam](#eduroam)(#on-kde-1) to proceed.
+
 ### Troubleshooting eduroam:
 eduroam seems to be the finickiest out of the 2, so if you run into issues, here are some steps you can take.
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ On Arch Linux this package is named `network-manager-applet` which can be found 
 On NixOS this package is name [`networkmanagerapplet`](https://github.com/NixOS/nixpkgs/blob/fe51d34885f7b5e3e7b59572796e1bcb427eccb1/pkgs/by-name/ne/networkmanagerapplet/package.nix#L88).
 This package should be widely availiable across most of the distros, search for your own package repository if you are not using the above distributions.
 
-After you have the package installed, launch it and follow the KDE section of [Main WiFi](#on-kde-1) and [Eduroam](#on-kde-2) to proceed.
+After you have the package installed, launch it and follow the KDE section of [Main WiFi](#on-kde) and [Eduroam](#on-kde-1) to proceed.
 
 Hopefully this documentation proved helpful, this was one of the major pain points that prevented me from daily-driving NixOS (or your preferred distribution) from sophomore year. Now that this is solved, I can finally make more progress of fully daily-driving NixOS, and I hope you do the same.
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ On Arch Linux this package is named `network-manager-applet` which can be found 
 On NixOS this package is name [`networkmanagerapplet`](https://github.com/NixOS/nixpkgs/blob/fe51d34885f7b5e3e7b59572796e1bcb427eccb1/pkgs/by-name/ne/networkmanagerapplet/package.nix#L88).
 This package should be widely availiable across most of the distros, search for your own package repository if you are not using the above distributions.
 
-After you have the package installed, launch it and follow the KDE section of [Main WiFi](#on-kde-1) and [Eduroam](#eduroam)(#on-kde-1) to proceed.
+After you have the package installed, launch it and follow the KDE section of [Main WiFi](#on-kde-1) and [Eduroam](#on-kde-2) to proceed.
 
 Hopefully this documentation proved helpful, this was one of the major pain points that prevented me from daily-driving NixOS (or your preferred distribution) from sophomore year. Now that this is solved, I can finally make more progress of fully daily-driving NixOS, and I hope you do the same.
 


### PR DESCRIPTION
Added documentation that is universal for any DE/WM people might be using without having to tie this documentation to only KDE and Gnome.

fix #1 